### PR TITLE
calculate panel size before showing it

### DIFF
--- a/Stats/Ui/MainPanel.cs
+++ b/Stats/Ui/MainPanel.cs
@@ -65,6 +65,7 @@
             CreateAndAddBackgroundPanel();
             CreateAndAddAllUiItems();
 
+            UpdateMainPanelAndItemColors();
             UpdateItemPanelButtonSizesAndLayoutAndPanelSize();
             UpdatePanelLayoutAndPanelSizeAndClampToScreen();
             UpdatePosition();


### PR DESCRIPTION
Without this, the panel will first show all items, making it vertically taller than the screen. Then the disabled ones will be hidden, but the resulting shrinking of the window will keep it at the top edge of the screen. With this fix, the window keeps its position.